### PR TITLE
fix: Update Rust Docker Image untuk Mendukung Edition 2024

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80-slim-bookworm AS builder
+FROM rust:1.85-slim-bookworm AS builder
 WORKDIR /app
 COPY . .
 RUN apt-get update && apt-get install -y pkg-config libssl-dev


### PR DESCRIPTION
Pull request ini memperbaiki bug kompilasi docker di mana Rust 1.80 lama ditolak oleh versi kargo modern `edition = 2024`. Tag default image dinaikkan ke `rust:1.85-slim-bookworm` sebagai standar *best practice* versi stabil agar kompilasi lancar jaya.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment base image to a newer version, improving build infrastructure stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->