### PR TITLE
fix: Gunakan Image Rust Terbaru untuk Kompilasi Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:slim-bookworm AS builder
 WORKDIR /app
 COPY . .
 RUN apt-get update && apt-get install -y pkg-config libssl-dev


### PR DESCRIPTION
Memperbaiki isu di mana library crate dependensi modern membutuhkan kompilator rustc di versi mutakhir (1.86+ / 1.88+). Memperbarui konfigurasi tag base image Dockerfile backend untuk merujuk pada `rust:slim-bookworm` (latest stable) menyelesaikan galat kompilasi tersebut.