### PR TITLE
fix: Penyesuaian Sintaks Route Parameter Axum 0.8

### DIFF
--- a/backend/src/users.rs
+++ b/backend/src/users.rs
@@ -11,7 +11,7 @@ use crate::{auth::RequireAuth, models::User, AppState};
 pub fn users_routes(state: AppState) -> Router<AppState> {
     Router::new()
         .route("/", get(list_users).post(create_user))
-        .route("/:id", put(update_user).delete(delete_user))
+        .route("/{id}", put(update_user).delete(delete_user))
         .with_state(state)
 }
 


### PR DESCRIPTION
Service backend di dalam Docker mati (*crash restart loop*) karena Axum v0.8.8 menolak penulisan parameter path lama bergaya `/:id`. Sekarang sudah diperbaiki menjadi konvensi `/{id}`. Silakan merge Pull Request ini lalu lakukan _rebuild_. Closes #1