### PR TITLE
fix: Next.js API Proxy & Validasi Akun Super Admin

### DIFF
--- a/backend/migrations/20260404000002_fix_admin_hash.sql
+++ b/backend/migrations/20260404000002_fix_admin_hash.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto; 
+UPDATE users SET password_hash = crypt('admin123', gen_salt('bf', 12)) WHERE nik = 'admin123';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     container_name: arff-frontend
     ports:
       - "3000:3000"
+    environment:
+      API_URL: http://arff-backend:8000
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
+const backendUrl = process.env.API_URL || 'http://localhost:8000';
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${backendUrl}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/dashboard/users/page.tsx
+++ b/frontend/src/app/dashboard/users/page.tsx
@@ -17,7 +17,7 @@ export default function UsersPage() {
 
   const fetchUsers = async () => {
     try {
-      const res = await fetch("http://localhost:8000/api/users", {
+      const res = await fetch("/api/users", {
         headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
       });
       if (!res.ok) throw new Error("Failed to fetch users");
@@ -35,7 +35,7 @@ export default function UsersPage() {
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch("http://localhost:8000/api/users", {
+      const res = await fetch("/api/users", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -12,7 +12,7 @@ export default function LoginPage() {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch("http://localhost:8000/api/auth/login", {
+      const res = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ident, password }),


### PR DESCRIPTION
Resolves `failed to fetch` problem. Mengubah arsitektur *fetch* dari Front-End dari yang tadinya menggunakan `localhost:8000` statis langsung (yang sering diblokir atau gagal di environment GitHub Codespace/VM) menjadi pola **API Proxy Rewrites** bawaan Next.js. Traffic API sekarang dirutekan via port 3000, lalu diteruskan internal docker Network ke `arff-backend:8000`. Selain itu, kami menyertakan _migration script_ sekunder untuk memastikan _hash_ `admin123` selaras tepat dengan _crypt_ standard pgcrypto agar tidak terkunci 401. Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin user password authentication issue

* **New Features**
  * Implemented API proxying to enable seamless frontend-backend communication

* **Chores**
  * Updated environment configuration for backend service connectivity
  * Refactored internal API request endpoints for improved deployment flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->